### PR TITLE
Some empty selector sets pass the previous guard clause

### DIFF
--- a/selector-set.js
+++ b/selector-set.js
@@ -305,7 +305,7 @@
   //
   // Returns Array of {selector, data, elements} matches.
   SelectorSet.prototype.queryAll = function(context) {
-    if (!this.selectors.length) {
+    if (this.selectors.length === 0) {
       return [];
     }
 


### PR DESCRIPTION
For example, we were seeing a selector of "" that didn't get caught, and subsequently raised an exception on down the line.
