### PR TITLE
Add UMD wrapper that works with browser/amd

### DIFF
--- a/selector-set.js
+++ b/selector-set.js
@@ -1,4 +1,13 @@
-(function(window) {
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(function () {
+      return factory(root);
+    });
+  } else {
+    // Public: Expose SelectorSet as a global on root.
+    root.SelectorSet = factory(root);
+  }
+})(this, function(window) {
   'use strict';
 
   // Public: Create a new SelectorSet.
@@ -404,6 +413,5 @@
     return matches.sort(sortById);
   };
 
-  // Public: Expose SelectorSet as a global on window.
-  window.SelectorSet = SelectorSet;
-})(window);
+  return SelectorSet;
+});


### PR DESCRIPTION
Adapted code from https://github.com/umdjs/umd/blob/master/amdWeb.js to wrap in UMD that registers as an anonymous AMD module. Note that no global will be exposed if AMD is used.
