### PR TITLE
Prefer standard `matches` function if available.

### DIFF
--- a/selector-set.js
+++ b/selector-set.js
@@ -26,7 +26,8 @@
 
   // Detect prefixed Element#matches function.
   var docElem = window.document.documentElement;
-  var matches = (docElem.webkitMatchesSelector ||
+  var matches = (docElem.matches ||
+                  docElem.webkitMatchesSelector ||
                   docElem.mozMatchesSelector ||
                   docElem.oMatchesSelector ||
                   docElem.msMatchesSelector);


### PR DESCRIPTION
The `matches` function is supported by [most browsers](http://caniuse.com/#feat=matchesselector) now. Adding it to the search list prepares for the removal of the prefixed functions in future browser versions.