### PR TITLE
Add version to npm manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "selector-set",
+  "version": "1.0.6",
+  "description": "An efficient data structure for matching and querying elements against a large set of CSS selectors.",
   "repository": {
     "type": "git",
     "url": "http://github.com/josh/selector-set.git"


### PR DESCRIPTION
Allows `selector-set` to be listed as a dependency in other packages.