### PR TITLE
Export SelectorSet as module

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "moduleIds": true,
+  "presets": [
+    "es2015-rollup"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components/
 node_modules/
+dist/

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
     "type": "git",
     "url": "http://github.com/josh/selector-set.git"
   },
-  "main": "selector-set.js",
+  "main": "dist/selector-set.js",
+  "jsnext:main": "selector-set.js",
   "devDependencies": {
+    "babel-plugin-transform-es2015-modules-amd": "^6.5.0",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-es2015-rollup": "^1.1.1",
     "benchmark": "^1.0.0",
     "bower": "~1.4.1",
     "d3": "^3.5.10",
@@ -18,12 +22,17 @@
     "grunt-contrib-qunit": "~0.3.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-saucelabs": "~4.1.0",
-    "qunitjs": "^1.20.0"
+    "qunitjs": "^1.20.0",
+    "rollup": "^0.25.4",
+    "rollup-plugin-babel": "^2.4.0"
   },
   "scripts": {
+    "build": "babel --plugins transform-es2015-modules-amd selector-set.js -d dist && rollup -c rollup.config.global.js",
+    "postbuild": "sed -i '' 's/\\/\\/ BUILD //g' dist/selector-set.js",
     "test": "grunt test"
   },
   "files": [
-    "selector-set.js"  
+    "selector-set.js",
+    "dist"
   ]
 }

--- a/rollup.config.global.js
+++ b/rollup.config.global.js
@@ -1,0 +1,8 @@
+import babel from 'rollup-plugin-babel';
+
+export default {
+  entry: 'selector-set.global.js',
+  dest: 'dist/selector-set.global.js',
+  format: 'iife',
+  plugins: [ babel() ]
+};

--- a/selector-set.global.js
+++ b/selector-set.global.js
@@ -1,0 +1,2 @@
+import SelectorSet from './selector-set';
+window.SelectorSet = SelectorSet;

--- a/selector-set.js
+++ b/selector-set.js
@@ -1,412 +1,410 @@
-(function(window) {
-  'use strict';
-
-  // Public: Create a new SelectorSet.
-  function SelectorSet() {
-    // Construct new SelectorSet if called as a function.
-    if (!(this instanceof SelectorSet)) {
-      return new SelectorSet();
-    }
-
-    // Public: Number of selectors added to the set
-    this.size = 0;
-
-    // Internal: Incrementing ID counter
-    this.uid = 0;
-
-    // Internal: Array of String selectors in the set
-    this.selectors = [];
-
-    // Internal: All Object index String names mapping to Index objects.
-    this.indexes = Object.create(this.indexes);
-
-    // Internal: Used Object index String names mapping to Index objects.
-    this.activeIndexes = [];
+// Public: Create a new SelectorSet.
+export default function SelectorSet() {
+  // Construct new SelectorSet if called as a function.
+  if (!(this instanceof SelectorSet)) {
+    return new SelectorSet();
   }
 
-  // Detect prefixed Element#matches function.
-  var docElem = window.document.documentElement;
-  var matches = (docElem.matches ||
-                  docElem.webkitMatchesSelector ||
-                  docElem.mozMatchesSelector ||
-                  docElem.oMatchesSelector ||
-                  docElem.msMatchesSelector);
+  // Public: Number of selectors added to the set
+  this.size = 0;
 
-  // Public: Check if element matches selector.
-  //
-  // Maybe overridden with custom Element.matches function.
-  //
-  // el       - An Element
-  // selector - String CSS selector
-  //
-  // Returns true or false.
-  SelectorSet.prototype.matchesSelector = function(el, selector) {
-    return matches.call(el, selector);
-  };
+  // Internal: Incrementing ID counter
+  this.uid = 0;
 
-  // Public: Find all elements in the context that match the selector.
-  //
-  // Maybe overridden with custom querySelectorAll function.
-  //
-  // selectors - String CSS selectors.
-  // context   - Element context
-  //
-  // Returns non-live list of Elements.
-  SelectorSet.prototype.querySelectorAll = function(selectors, context) {
-    return context.querySelectorAll(selectors);
-  };
+  // Internal: Array of String selectors in the set
+  this.selectors = [];
+
+  // Internal: All Object index String names mapping to Index objects.
+  this.indexes = Object.create(this.indexes);
+
+  // Internal: Used Object index String names mapping to Index objects.
+  this.activeIndexes = [];
+}
+
+// Detect prefixed Element#matches function.
+var docElem = window.document.documentElement;
+var matches = (docElem.matches ||
+                docElem.webkitMatchesSelector ||
+                docElem.mozMatchesSelector ||
+                docElem.oMatchesSelector ||
+                docElem.msMatchesSelector);
+
+// Public: Check if element matches selector.
+//
+// Maybe overridden with custom Element.matches function.
+//
+// el       - An Element
+// selector - String CSS selector
+//
+// Returns true or false.
+SelectorSet.prototype.matchesSelector = function(el, selector) {
+  return matches.call(el, selector);
+};
+
+// Public: Find all elements in the context that match the selector.
+//
+// Maybe overridden with custom querySelectorAll function.
+//
+// selectors - String CSS selectors.
+// context   - Element context
+//
+// Returns non-live list of Elements.
+SelectorSet.prototype.querySelectorAll = function(selectors, context) {
+  return context.querySelectorAll(selectors);
+};
 
 
-  // Public: Array of indexes.
-  //
-  // name     - Unique String name
-  // selector - Function that takes a String selector and returns a String key
-  //            or undefined if it can't be used by the index.
-  // element  - Function that takes an Element and returns an Array of String
-  //            keys that point to indexed values.
-  //
-  SelectorSet.prototype.indexes = [];
+// Public: Array of indexes.
+//
+// name     - Unique String name
+// selector - Function that takes a String selector and returns a String key
+//            or undefined if it can't be used by the index.
+// element  - Function that takes an Element and returns an Array of String
+//            keys that point to indexed values.
+//
+SelectorSet.prototype.indexes = [];
 
-  // Index by element id
-  var idRe = /^#((?:[\w\u00c0-\uFFFF\-]|\\.)+)/g;
-  SelectorSet.prototype.indexes.push({
-    name: 'ID',
-    selector: function matchIdSelector(sel) {
-      var m;
-      if (m = sel.match(idRe)) {
-        return m[0].slice(1);
-      }
-    },
-    element: function getElementId(el) {
-      if (el.id) {
-        return [el.id];
-      }
+// Index by element id
+var idRe = /^#((?:[\w\u00c0-\uFFFF\-]|\\.)+)/g;
+SelectorSet.prototype.indexes.push({
+  name: 'ID',
+  selector: function matchIdSelector(sel) {
+    var m;
+    if (m = sel.match(idRe)) {
+      return m[0].slice(1);
     }
-  });
-
-  // Index by all of its class names
-  var classRe = /^\.((?:[\w\u00c0-\uFFFF\-]|\\.)+)/g;
-  SelectorSet.prototype.indexes.push({
-    name: 'CLASS',
-    selector: function matchClassSelector(sel) {
-      var m;
-      if (m = sel.match(classRe)) {
-        return m[0].slice(1);
-      }
-    },
-    element: function getElementClassNames(el) {
-      var className = el.className;
-      if (className) {
-        if (typeof className === 'string') {
-          return className.split(/\s/);
-        } else if (typeof className === 'object' && 'baseVal' in className) {
-          // className is a SVGAnimatedString
-          // global SVGAnimatedString is not an exposed global in Opera 12
-          return className.baseVal.split(/\s/);
-        }
-      }
+  },
+  element: function getElementId(el) {
+    if (el.id) {
+      return [el.id];
     }
-  });
-
-  // Index by tag/node name: `DIV`, `FORM`, `A`
-  var tagRe = /^((?:[\w\u00c0-\uFFFF\-]|\\.)+)/g;
-  SelectorSet.prototype.indexes.push({
-    name: 'TAG',
-    selector: function matchTagSelector(sel) {
-      var m;
-      if (m = sel.match(tagRe)) {
-        return m[0].toUpperCase();
-      }
-    },
-    element: function getElementTagName(el) {
-      return [el.nodeName.toUpperCase()];
-    }
-  });
-
-  // Default index just contains a single array of elements.
-  SelectorSet.prototype.indexes['default'] = {
-    name: 'UNIVERSAL',
-    selector: function() {
-      return true;
-    },
-    element: function() {
-      return [true];
-    }
-  };
-
-
-  // Use ES Maps when supported
-  var Map;
-  if (typeof window.Map === 'function') {
-    Map = window.Map;
-  } else {
-    Map = (function() {
-      function Map() {
-        this.map = {};
-      }
-      Map.prototype.get = function(key) {
-        return this.map[key + ' '];
-      };
-      Map.prototype.set = function(key, value) {
-        this.map[key + ' '] = value;
-      };
-      return Map;
-    })();
   }
+});
 
-
-  // Regexps adopted from Sizzle
-  //   https://github.com/jquery/sizzle/blob/1.7/sizzle.js
-  //
-  var chunker = /((?:\((?:\([^()]+\)|[^()]+)+\)|\[(?:\[[^\[\]]*\]|['"][^'"]*['"]|[^\[\]'"]+)+\]|\\.|[^ >+~,(\[\\]+)+|[>+~])(\s*,\s*)?((?:.|\r|\n)*)/g;
-
-  // Internal: Get indexes for selector.
-  //
-  // selector - String CSS selector
-  //
-  // Returns Array of {index, key}.
-  function parseSelectorIndexes(allIndexes, selector) {
-    allIndexes = allIndexes.slice(0).concat(allIndexes['default']);
-
-    var allIndexesLen = allIndexes.length,
-        i, j, m, dup, rest = selector,
-        key, index, indexes = [];
-
-    do {
-      chunker.exec('');
-      if (m = chunker.exec(rest)) {
-        rest = m[3];
-        if (m[2] || !rest) {
-          for (i = 0; i < allIndexesLen; i++) {
-            index = allIndexes[i];
-            if (key = index.selector(m[1])) {
-              j = indexes.length;
-              dup = false;
-              while (j--) {
-                if (indexes[j].index === index && indexes[j].key === key) {
-                  dup = true;
-                  break;
-                }
-              }
-              if (!dup) {
-                indexes.push({index: index, key: key});
-              }
-              break;
-            }
-          }
-        }
-      }
-    } while (m);
-
-    return indexes;
-  }
-
-  // Internal: Find first item in Array that is a prototype of `proto`.
-  //
-  // ary   - Array of objects
-  // proto - Prototype of expected item in `ary`
-  //
-  // Returns object from `ary` if found. Otherwise returns undefined.
-  function findByPrototype(ary, proto) {
-    var i, len, item;
-    for (i = 0, len = ary.length; i < len; i++) {
-      item = ary[i];
-      if (proto.isPrototypeOf(item)) {
-        return item;
+// Index by all of its class names
+var classRe = /^\.((?:[\w\u00c0-\uFFFF\-]|\\.)+)/g;
+SelectorSet.prototype.indexes.push({
+  name: 'CLASS',
+  selector: function matchClassSelector(sel) {
+    var m;
+    if (m = sel.match(classRe)) {
+      return m[0].slice(1);
+    }
+  },
+  element: function getElementClassNames(el) {
+    var className = el.className;
+    if (className) {
+      if (typeof className === 'string') {
+        return className.split(/\s/);
+      } else if (typeof className === 'object' && 'baseVal' in className) {
+        // className is a SVGAnimatedString
+        // global SVGAnimatedString is not an exposed global in Opera 12
+        return className.baseVal.split(/\s/);
       }
     }
   }
+});
 
-  // Public: Log when added selector falls under the default index.
-  //
-  // This API should not be considered stable. May change between
-  // minor versions.
-  //
-  // obj - {selector, data} Object
-  //
-  //   SelectorSet.prototype.logDefaultIndexUsed = function(obj) {
-  //     console.warn(obj.selector, "could not be indexed");
-  //   };
-  //
-  // Returns nothing.
-  SelectorSet.prototype.logDefaultIndexUsed = function() {};
-
-  // Public: Add selector to set.
-  //
-  // selector - String CSS selector
-  // data     - Optional data Object (default: undefined)
-  //
-  // Returns nothing.
-  SelectorSet.prototype.add = function(selector, data) {
-    var obj, i, indexProto, key, index, objs,
-        selectorIndexes, selectorIndex,
-        indexes = this.activeIndexes,
-        selectors = this.selectors;
-
-    if (typeof selector !== 'string') {
-      return;
+// Index by tag/node name: `DIV`, `FORM`, `A`
+var tagRe = /^((?:[\w\u00c0-\uFFFF\-]|\\.)+)/g;
+SelectorSet.prototype.indexes.push({
+  name: 'TAG',
+  selector: function matchTagSelector(sel) {
+    var m;
+    if (m = sel.match(tagRe)) {
+      return m[0].toUpperCase();
     }
+  },
+  element: function getElementTagName(el) {
+    return [el.nodeName.toUpperCase()];
+  }
+});
 
-    obj = {
-      id: this.uid++,
-      selector: selector,
-      data: data
+// Default index just contains a single array of elements.
+SelectorSet.prototype.indexes['default'] = {
+  name: 'UNIVERSAL',
+  selector: function() {
+    return true;
+  },
+  element: function() {
+    return [true];
+  }
+};
+
+
+// Use ES Maps when supported
+var Map;
+if (typeof window.Map === 'function') {
+  Map = window.Map;
+} else {
+  Map = (function() {
+    function Map() {
+      this.map = {};
+    }
+    Map.prototype.get = function(key) {
+      return this.map[key + ' '];
     };
+    Map.prototype.set = function(key, value) {
+      this.map[key + ' '] = value;
+    };
+    return Map;
+  })();
+}
 
-    selectorIndexes = parseSelectorIndexes(this.indexes, selector);
-    for (i = 0; i < selectorIndexes.length; i++) {
-      selectorIndex = selectorIndexes[i];
-      key = selectorIndex.key;
-      indexProto = selectorIndex.index;
 
-      index = findByPrototype(indexes, indexProto);
-      if (!index) {
-        index = Object.create(indexProto);
-        index.map = new Map();
-        indexes.push(index);
-      }
+// Regexps adopted from Sizzle
+//   https://github.com/jquery/sizzle/blob/1.7/sizzle.js
+//
+var chunker = /((?:\((?:\([^()]+\)|[^()]+)+\)|\[(?:\[[^\[\]]*\]|['"][^'"]*['"]|[^\[\]'"]+)+\]|\\.|[^ >+~,(\[\\]+)+|[>+~])(\s*,\s*)?((?:.|\r|\n)*)/g;
 
-      if (indexProto === this.indexes['default']) {
-        this.logDefaultIndexUsed(obj);
-      }
-      objs = index.map.get(key);
-      if (!objs) {
-        objs = [];
-        index.map.set(key, objs);
-      }
-      objs.push(obj);
-    }
+// Internal: Get indexes for selector.
+//
+// selector - String CSS selector
+//
+// Returns Array of {index, key}.
+function parseSelectorIndexes(allIndexes, selector) {
+  allIndexes = allIndexes.slice(0).concat(allIndexes['default']);
 
-    this.size++;
-    selectors.push(selector);
-  };
+  var allIndexesLen = allIndexes.length,
+      i, j, m, dup, rest = selector,
+      key, index, indexes = [];
 
-  // Public: Remove selector from set.
-  //
-  // selector - String CSS selector
-  // data     - Optional data Object (default: undefined)
-  //
-  // Returns nothing.
-  SelectorSet.prototype.remove = function(selector, data) {
-    if (typeof selector !== 'string') {
-      return;
-    }
-
-    var selectorIndexes, selectorIndex, i, j, k, selIndex, objs, obj;
-    var indexes = this.activeIndexes;
-    var removedIds = {};
-    var removeAll = arguments.length === 1;
-
-    selectorIndexes = parseSelectorIndexes(this.indexes, selector);
-    for (i = 0; i < selectorIndexes.length; i++) {
-      selectorIndex = selectorIndexes[i];
-
-      j = indexes.length;
-      while (j--) {
-        selIndex = indexes[j];
-        if (selectorIndex.index.isPrototypeOf(selIndex)) {
-          objs = selIndex.map.get(selectorIndex.key);
-          if (objs) {
-            k = objs.length;
-            while (k--) {
-              obj = objs[k];
-              if (obj.selector === selector && (removeAll || obj.data === data)) {
-                objs.splice(k, 1);
-                removedIds[obj.id] = true;
+  do {
+    chunker.exec('');
+    if (m = chunker.exec(rest)) {
+      rest = m[3];
+      if (m[2] || !rest) {
+        for (i = 0; i < allIndexesLen; i++) {
+          index = allIndexes[i];
+          if (key = index.selector(m[1])) {
+            j = indexes.length;
+            dup = false;
+            while (j--) {
+              if (indexes[j].index === index && indexes[j].key === key) {
+                dup = true;
+                break;
               }
             }
+            if (!dup) {
+              indexes.push({index: index, key: key});
+            }
+            break;
           }
-          break;
         }
       }
     }
+  } while (m);
 
-    this.size -= Object.keys(removedIds).length;
-  };
+  return indexes;
+}
 
-  // Sort by id property handler.
-  //
-  // a - Selector obj.
-  // b - Selector obj.
-  //
-  // Returns Number.
-  function sortById(a, b) {
-    return a.id - b.id;
+// Internal: Find first item in Array that is a prototype of `proto`.
+//
+// ary   - Array of objects
+// proto - Prototype of expected item in `ary`
+//
+// Returns object from `ary` if found. Otherwise returns undefined.
+function findByPrototype(ary, proto) {
+  var i, len, item;
+  for (i = 0, len = ary.length; i < len; i++) {
+    item = ary[i];
+    if (proto.isPrototypeOf(item)) {
+      return item;
+    }
+  }
+}
+
+// Public: Log when added selector falls under the default index.
+//
+// This API should not be considered stable. May change between
+// minor versions.
+//
+// obj - {selector, data} Object
+//
+//   SelectorSet.prototype.logDefaultIndexUsed = function(obj) {
+//     console.warn(obj.selector, "could not be indexed");
+//   };
+//
+// Returns nothing.
+SelectorSet.prototype.logDefaultIndexUsed = function() {};
+
+// Public: Add selector to set.
+//
+// selector - String CSS selector
+// data     - Optional data Object (default: undefined)
+//
+// Returns nothing.
+SelectorSet.prototype.add = function(selector, data) {
+  var obj, i, indexProto, key, index, objs,
+      selectorIndexes, selectorIndex,
+      indexes = this.activeIndexes,
+      selectors = this.selectors;
+
+  if (typeof selector !== 'string') {
+    return;
   }
 
-  // Public: Find all matching decendants of the context element.
-  //
-  // context - An Element
-  //
-  // Returns Array of {selector, data, elements} matches.
-  SelectorSet.prototype.queryAll = function(context) {
-    if (!this.selectors.length) {
-      return [];
-    }
+  const asdf = 12;
 
-    var matches = {}, results = [];
-    var els = this.querySelectorAll(this.selectors.join(', '), context);
-
-    var i, j, len, len2, el, m, match, obj;
-    for (i = 0, len = els.length; i < len; i++) {
-      el = els[i];
-      m = this.matches(el);
-      for (j = 0, len2 = m.length; j < len2; j++) {
-        obj = m[j];
-        if (!matches[obj.id]) {
-          match = {
-            id: obj.id,
-            selector: obj.selector,
-            data: obj.data,
-            elements: []
-          };
-          matches[obj.id] = match;
-          results.push(match);
-        } else {
-          match = matches[obj.id];
-        }
-        match.elements.push(el);
-      }
-    }
-
-    return results.sort(sortById);
+  obj = {
+    id: this.uid++,
+    selector: selector,
+    data: data
   };
 
-  // Public: Match element against all selectors in set.
-  //
-  // el - An Element
-  //
-  // Returns Array of {selector, data} matches.
-  SelectorSet.prototype.matches = function(el) {
-    if (!el) {
-      return [];
+  selectorIndexes = parseSelectorIndexes(this.indexes, selector);
+  for (i = 0; i < selectorIndexes.length; i++) {
+    selectorIndex = selectorIndexes[i];
+    key = selectorIndex.key;
+    indexProto = selectorIndex.index;
+
+    index = findByPrototype(indexes, indexProto);
+    if (!index) {
+      index = Object.create(indexProto);
+      index.map = new Map();
+      indexes.push(index);
     }
 
-    var i, j, k, len, len2, len3, index, keys, objs, obj, id;
-    var indexes = this.activeIndexes, matchedIds = {}, matches = [];
+    if (indexProto === this.indexes['default']) {
+      this.logDefaultIndexUsed(obj);
+    }
+    objs = index.map.get(key);
+    if (!objs) {
+      objs = [];
+      index.map.set(key, objs);
+    }
+    objs.push(obj);
+  }
 
-    for (i = 0, len = indexes.length; i < len; i++) {
-      index = indexes[i];
-      keys = index.element(el);
-      if (keys) {
-        for (j = 0, len2 = keys.length; j < len2; j++) {
-          if (objs = index.map.get(keys[j])) {
-            for (k = 0, len3 = objs.length; k < len3; k++) {
-              obj = objs[k];
-              id = obj.id;
-              if (!matchedIds[id] && this.matchesSelector(el, obj.selector)) {
-                matchedIds[id] = true;
-                matches.push(obj);
-              }
+  this.size++;
+  selectors.push(selector);
+};
+
+// Public: Remove selector from set.
+//
+// selector - String CSS selector
+// data     - Optional data Object (default: undefined)
+//
+// Returns nothing.
+SelectorSet.prototype.remove = function(selector, data) {
+  if (typeof selector !== 'string') {
+    return;
+  }
+
+  var selectorIndexes, selectorIndex, i, j, k, selIndex, objs, obj;
+  var indexes = this.activeIndexes;
+  var removedIds = {};
+  var removeAll = arguments.length === 1;
+
+  selectorIndexes = parseSelectorIndexes(this.indexes, selector);
+  for (i = 0; i < selectorIndexes.length; i++) {
+    selectorIndex = selectorIndexes[i];
+
+    j = indexes.length;
+    while (j--) {
+      selIndex = indexes[j];
+      if (selectorIndex.index.isPrototypeOf(selIndex)) {
+        objs = selIndex.map.get(selectorIndex.key);
+        if (objs) {
+          k = objs.length;
+          while (k--) {
+            obj = objs[k];
+            if (obj.selector === selector && (removeAll || obj.data === data)) {
+              objs.splice(k, 1);
+              removedIds[obj.id] = true;
+            }
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  this.size -= Object.keys(removedIds).length;
+};
+
+// Sort by id property handler.
+//
+// a - Selector obj.
+// b - Selector obj.
+//
+// Returns Number.
+function sortById(a, b) {
+  return a.id - b.id;
+}
+
+// Public: Find all matching decendants of the context element.
+//
+// context - An Element
+//
+// Returns Array of {selector, data, elements} matches.
+SelectorSet.prototype.queryAll = function(context) {
+  if (!this.selectors.length) {
+    return [];
+  }
+
+  var matches = {}, results = [];
+  var els = this.querySelectorAll(this.selectors.join(', '), context);
+
+  var i, j, len, len2, el, m, match, obj;
+  for (i = 0, len = els.length; i < len; i++) {
+    el = els[i];
+    m = this.matches(el);
+    for (j = 0, len2 = m.length; j < len2; j++) {
+      obj = m[j];
+      if (!matches[obj.id]) {
+        match = {
+          id: obj.id,
+          selector: obj.selector,
+          data: obj.data,
+          elements: []
+        };
+        matches[obj.id] = match;
+        results.push(match);
+      } else {
+        match = matches[obj.id];
+      }
+      match.elements.push(el);
+    }
+  }
+
+  return results.sort(sortById);
+};
+
+// Public: Match element against all selectors in set.
+//
+// el - An Element
+//
+// Returns Array of {selector, data} matches.
+SelectorSet.prototype.matches = function(el) {
+  if (!el) {
+    return [];
+  }
+
+  var i, j, k, len, len2, len3, index, keys, objs, obj, id;
+  var indexes = this.activeIndexes, matchedIds = {}, matches = [];
+
+  for (i = 0, len = indexes.length; i < len; i++) {
+    index = indexes[i];
+    keys = index.element(el);
+    if (keys) {
+      for (j = 0, len2 = keys.length; j < len2; j++) {
+        if (objs = index.map.get(keys[j])) {
+          for (k = 0, len3 = objs.length; k < len3; k++) {
+            obj = objs[k];
+            id = obj.id;
+            if (!matchedIds[id] && this.matchesSelector(el, obj.selector)) {
+              matchedIds[id] = true;
+              matches.push(obj);
             }
           }
         }
       }
     }
+  }
 
-    return matches.sort(sortById);
-  };
+  return matches.sort(sortById);
+};
 
-  // Public: Expose SelectorSet as a global on window.
-  window.SelectorSet = SelectorSet;
-})(window);
+// Public: Expose SelectorSet as a global on window.
+// BUILD window.SelectorSet = SelectorSet;

--- a/selector-set.js
+++ b/selector-set.js
@@ -244,8 +244,6 @@ SelectorSet.prototype.add = function(selector, data) {
     return;
   }
 
-  const asdf = 12;
-
   obj = {
     id: this.uid++,
     selector: selector,

--- a/test/perf.html
+++ b/test/perf.html
@@ -39,7 +39,7 @@
 
   <script src="../node_modules/d3/d3.js"></script>
   <script src="../node_modules/benchmark/benchmark.js"></script>
-  <script src="../selector-set.js"></script>
+  <script src="../dist/selector-set.global.js"></script>
   <script src="./exemplar-selector-set.js"></script>
   <script src="./perf.js"></script>
   <script>

--- a/test/test-exemplar.html
+++ b/test/test-exemplar.html
@@ -36,7 +36,7 @@
 
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
 
-  <script src="../selector-set.js"></script>
+  <script src="../dist/selector-set.global.js"></script>
   <script src="./exemplar-selector-set.js"></script>
 
   <script>

--- a/test/test-fuzz.html
+++ b/test/test-fuzz.html
@@ -12,7 +12,7 @@
 
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
 
-  <script src="../selector-set.js"></script>
+  <script src="../dist/selector-set.global.js"></script>
   <script src="./exemplar-selector-set.js"></script>
 
   <script src="./fuzz.js"></script>

--- a/test/test.html
+++ b/test/test.html
@@ -36,7 +36,7 @@
 
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
 
-  <script src="../selector-set.js"></script>
+  <script src="../dist/selector-set.global.js"></script>
 
   <script src="./unit/add.js"></script>
   <script src="./unit/matches.js"></script>


### PR DESCRIPTION
This branch handles three module usage scenarios, listed from most desirable to least.

1. Native JS module syntax. The `jsnext:main` attribute points to the pure module in `selector-set.js`. This allows rollup, and other modern JS toolchains, to just use the normal JS file. This would be used by the [`delegated-events`](https://github.com/dgraham/delegated-events) module that depends on `selector-set`.
2. AMD plus window global. The `main` attribute points to a compiled `dist/selector-set.js` that defines a module in an AMD registry. It also leaks a `window.SelectorSet` global. This allows AMD toolchains to require the module, while also allowing [`jquery-selector-set`](https://github.com/josh/jquery-selector-set) to continue to refer to the window global. We would use this on github.com while transitioning to native modules.
3. Global `window.SelectorSet`. This provides backward compatibility for script tag usage. The only change is to the file name: `dist/selector-set.global.js`.

In #17 we have two separate implementations of `selector-set.js` that would need to be maintained together. The aim of this proposal is to author one file in standard JS modules and use the build toolchain to create backward compatible AMD and window global files.

@josh