### PR TITLE
Use module key for native module file

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "main": "selector-set.js",
   "module": "selector-set.next.js",
+  "jsnext:main": "selector-set.next.js",
   "devDependencies": {
     "benchmark": "^1.0.0",
     "bower": "~1.4.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/josh/selector-set.git"
   },
   "main": "selector-set.js",
-  "jsnext:main": "selector-set.next.js",
+  "module": "selector-set.next.js",
   "devDependencies": {
     "benchmark": "^1.0.0",
     "bower": "~1.4.1",


### PR DESCRIPTION
Looks like `module` is the new and [preferred](https://github.com/rollup/rollup/wiki/pkg.module) name for `jsnext:main` in rollup and webpack.