### PR TITLE
Test removal of selectors

### DIFF
--- a/selector-set.js
+++ b/selector-set.js
@@ -302,9 +302,8 @@
 
     var selectorIndexes, selectorIndex, i, j, k, selIndex, objs, obj;
     var indexes = this.activeIndexes;
-    var removedIds = {};
+    var removedIds = {}, removedSelectors = {};
     var removeAll = arguments.length === 1;
-    var selectors = this.selectors;
 
     selectorIndexes = parseSelectorIndexes(this.indexes, selector);
     for (i = 0; i < selectorIndexes.length; i++) {
@@ -321,7 +320,8 @@
               obj = objs[k];
               if (obj.selector === selector && (removeAll || obj.data === data)) {
                 objs.splice(k, 1);
-                removedIds[obj.id] = obj.selector;
+                removedIds[obj.id] = true;
+                removedSelectors[obj.selector] = true;
               }
             }
           }
@@ -330,10 +330,7 @@
       }
     }
     this.size -= Object.keys(removedIds).length;
-    Object.values(removedIds).forEach(function (selector) {
-      let idx = selectors.indexOf(selector)
-      if (idx >= 0) selectors.splice(idx, 1)
-    })
+    this.selectors = this.selectors.filter(selector => removedSelectors[selector])
   };
 
   // Sort by id property handler.

--- a/selector-set.js
+++ b/selector-set.js
@@ -330,7 +330,7 @@
       }
     }
     this.size -= Object.keys(removedIds).length;
-    this.selectors = this.selectors.filter(selector => removedSelectors[selector])
+    this.selectors = this.selectors.filter(function (selector) { return removedSelectors[selector] })
   };
 
   // Sort by id property handler.

--- a/selector-set.js
+++ b/selector-set.js
@@ -304,6 +304,7 @@
     var indexes = this.activeIndexes;
     var removedIds = {};
     var removeAll = arguments.length === 1;
+    var selectors = this.selectors;
 
     selectorIndexes = parseSelectorIndexes(this.indexes, selector);
     for (i = 0; i < selectorIndexes.length; i++) {
@@ -320,7 +321,7 @@
               obj = objs[k];
               if (obj.selector === selector && (removeAll || obj.data === data)) {
                 objs.splice(k, 1);
-                removedIds[obj.id] = true;
+                removedIds[obj.id] = obj.selector;
               }
             }
           }
@@ -328,8 +329,11 @@
         }
       }
     }
-
     this.size -= Object.keys(removedIds).length;
+    Object.values(removedIds).forEach(function (selector) {
+      let idx = selectors.indexOf(selector)
+      if (idx >= 0) selectors.splice(idx, 1)
+    })
   };
 
   // Sort by id property handler.

--- a/selector-set.next.js
+++ b/selector-set.next.js
@@ -293,6 +293,7 @@ SelectorSet.prototype.remove = function(selector, data) {
   var indexes = this.activeIndexes;
   var removedIds = {};
   var removeAll = arguments.length === 1;
+  var selectors = this.selectors;
 
   selectorIndexes = parseSelectorIndexes(this.indexes, selector);
   for (i = 0; i < selectorIndexes.length; i++) {
@@ -309,7 +310,7 @@ SelectorSet.prototype.remove = function(selector, data) {
             obj = objs[k];
             if (obj.selector === selector && (removeAll || obj.data === data)) {
               objs.splice(k, 1);
-              removedIds[obj.id] = true;
+              removedIds[obj.id] = obj.selector;
             }
           }
         }
@@ -319,6 +320,10 @@ SelectorSet.prototype.remove = function(selector, data) {
   }
 
   this.size -= Object.keys(removedIds).length;
+  Object.values(removedIds).forEach((selector) => {
+    let idx = selectors.indexOf(selector)
+    if (idx >= 0) selectors.splice(idx, 1)
+  })
 };
 
 // Sort by id property handler.

--- a/selector-set.next.js
+++ b/selector-set.next.js
@@ -291,9 +291,8 @@ SelectorSet.prototype.remove = function(selector, data) {
 
   var selectorIndexes, selectorIndex, i, j, k, selIndex, objs, obj;
   var indexes = this.activeIndexes;
-  var removedIds = {};
+  var removedIds = {}, removedSelectors = {};
   var removeAll = arguments.length === 1;
-  var selectors = this.selectors;
 
   selectorIndexes = parseSelectorIndexes(this.indexes, selector);
   for (i = 0; i < selectorIndexes.length; i++) {
@@ -310,7 +309,8 @@ SelectorSet.prototype.remove = function(selector, data) {
             obj = objs[k];
             if (obj.selector === selector && (removeAll || obj.data === data)) {
               objs.splice(k, 1);
-              removedIds[obj.id] = obj.selector;
+              removedIds[obj.id] = true;
+              removedSelectors[obj.selector] = true;
             }
           }
         }
@@ -320,10 +320,7 @@ SelectorSet.prototype.remove = function(selector, data) {
   }
 
   this.size -= Object.keys(removedIds).length;
-  Object.values(removedIds).forEach((selector) => {
-    let idx = selectors.indexOf(selector)
-    if (idx >= 0) selectors.splice(idx, 1)
-  })
+  this.selectors = this.selectors.filter(selector => removedSelectors[selector]);
 };
 
 // Sort by id property handler.

--- a/test/unit/add.js
+++ b/test/unit/add.js
@@ -44,5 +44,7 @@
 
     set.remove('#bar');
     equal(set.size, 0);
+
+    equal(set.selectors.length, 0);
   });
 })();


### PR DESCRIPTION
This fixes #26.
`this.selectors` seems to be a shallow property, not engaged in internal logic, so we can safely remove items from it.
@josh 